### PR TITLE
Possible solution for #6463 to allow :${stageVariables.___} suffix in function name

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_permission.go
+++ b/builtin/providers/aws/resource_aws_lambda_permission.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-var LambdaFunctionRegexp = `^(arn:[\w-]+:lambda:)?([a-z]{2}-[a-z]+-\d{1}:)?(\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\$LATEST|[a-zA-Z0-9-_]+))?$`
+var LambdaFunctionRegexp = `^(arn:[\w-]+:lambda:)?([a-z]{2}-[a-z]+-\d{1}:)?(\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\$LATEST|\${stageVariables[.][a-zA-Z0-9-_]+}|[a-zA-Z0-9-_]+))?$`
 
 func resourceAwsLambdaPermission() *schema.Resource {
 	return &schema.Resource{


### PR DESCRIPTION
Confession: I don't have a Terraform development environment. I created this mostly to bookmark the possible location to fix #6463, with a (likely too simplistic, possibly erroneous) minimal fix that would unblock my own attempt to use Terraform for my application. I'm hoping someone with a test environment could confirm if this is right. I just realized this is not the file I thought it was. The actual error I get is in my aws_lambda_permission's function_name argument when I use this syntax. I'm going to look for that file and make the same change there.